### PR TITLE
Fix(background): Update the link for openscn

### DIFF
--- a/src/content/pages/Background/data.js
+++ b/src/content/pages/Background/data.js
@@ -105,7 +105,7 @@ const communityTable = {
   content: [
     {
       data: [
-        <a target="_blank" href="https://openscn.gitlab.io/documentation/">
+        <a target="_blank" href="https://openscn.io">
           <OpenSCN class="background__svg" />
           OpenSCN
         </a>,


### PR DESCRIPTION
This PR is replaces the link to the openSCN webpage. It uses the `openscn.io` domain

Fix #5